### PR TITLE
Switch API endpoint when asking for the list of roles

### DIFF
--- a/endpoints/kettle/admin/listRoles.ktr
+++ b/endpoints/kettle/admin/listRoles.ktr
@@ -323,7 +323,7 @@
     <isBypassingAuthentication>Y</isBypassingAuthentication>
     <moduleName>platform</moduleName>
     <isModuleFromField>N</isModuleFromField>
-    <endpointPath>&#x2f;userroledao&#x2f;roles</endpointPath>
+    <endpointPath>&#x2f;userrolelist&#x2f;allRoles</endpointPath>
     <httpMethod>GET</httpMethod>
     <isEndpointFromField>N</isEndpointFromField>
     <resultField>result</resultField>


### PR DESCRIPTION
This will change the endpoint used to fetch the list of available roles from `userroledao/roles` to `userrolelist/allRoles`, so all roles are properly returned in a hybrid JDBC/LDAP configuration.
